### PR TITLE
v0.2.0: Self-contained viewer.html with XSS protection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "noodles"
-version = "0.1.1"
+version = "0.2.0"
 description = "AI-powered code visualization and call graph analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/noodles/agents/pr_analyzer/pr_analyzer.py
+++ b/src/noodles/agents/pr_analyzer/pr_analyzer.py
@@ -114,13 +114,9 @@ async def analyze_pr(
         sub_file.write_text(sub_content)
         print(f"  Sub-diagram:   {sub_file}")
 
-    # Step 6: Generate viewer bundle for the website
-    print("Generating viewer bundle ...")
-    from noodles.viewer.data_loader import load_result
-    viewer_bundle = load_result(result_dir)
-    viewer_bundle_file = result_dir / "viewer_bundle.json"
-    viewer_bundle_file.write_text(json.dumps(viewer_bundle))
-    print(f"  Viewer bundle: {viewer_bundle_file}")
+    # Step 6: Generate viewer bundle and HTML
+    from noodles.viewer.data_loader import write_viewer_files
+    write_viewer_files(result_dir)
 
     return result_dir
 

--- a/src/noodles/agents/pr_analyzer/pr_analyzer.py
+++ b/src/noodles/agents/pr_analyzer/pr_analyzer.py
@@ -113,6 +113,14 @@ async def analyze_pr(
         sub_file.write_text(sub_content)
         print(f"  Sub-diagram:   {sub_file}")
 
+    # Step 6: Generate viewer bundle for the website
+    print("Generating viewer bundle ...")
+    from noodles.viewer.data_loader import load_result
+    viewer_bundle = load_result(result_dir)
+    viewer_bundle_file = result_dir / "viewer_bundle.json"
+    viewer_bundle_file.write_text(json.dumps(viewer_bundle))
+    print(f"  Viewer bundle: {viewer_bundle_file}")
+
     return result_dir
 
 

--- a/src/noodles/agents/pr_analyzer/pr_analyzer.py
+++ b/src/noodles/agents/pr_analyzer/pr_analyzer.py
@@ -6,6 +6,7 @@ Usage:
 
 import asyncio
 import json
+import os
 import re
 import subprocess
 import sys
@@ -198,6 +199,13 @@ def _clone_and_setup(
     print(f"  Cloning {owner}/{repo} ...")
     if not _run_git(["gh", "repo", "clone", f"{owner}/{repo}", str(repo_dir)], timeout=300):
         return None
+
+    # Configure git to use GH_TOKEN for authentication (gh clone doesn't set this up)
+    gh_token = os.environ.get("GH_TOKEN")
+    if gh_token:
+        # Update remote URL to include token for authentication
+        auth_url = f"https://x-access-token:{gh_token}@github.com/{owner}/{repo}.git"
+        _run_git(["git", "remote", "set-url", "origin", auth_url], cwd=repo_dir)
 
     # Fetch the PR head ref
     print(f"  Fetching PR #{pr_number} head ...")

--- a/src/noodles/agents/repo_analyzer/repo_analyzer.py
+++ b/src/noodles/agents/repo_analyzer/repo_analyzer.py
@@ -88,6 +88,14 @@ async def analyze_repo(
         sub_file.write_text(sub_content)
         print(f"  Sub-diagram:   {sub_file}")
 
+    # Step 6: Generate viewer bundle for the website
+    print("Generating viewer bundle ...")
+    from noodles.viewer.data_loader import load_result
+    viewer_bundle = load_result(result_dir)
+    viewer_bundle_file = result_dir / "viewer_bundle.json"
+    viewer_bundle_file.write_text(json.dumps(viewer_bundle))
+    print(f"  Viewer bundle: {viewer_bundle_file}")
+
     return result_dir
 
 

--- a/src/noodles/agents/repo_analyzer/repo_analyzer.py
+++ b/src/noodles/agents/repo_analyzer/repo_analyzer.py
@@ -88,13 +88,9 @@ async def analyze_repo(
         sub_file.write_text(sub_content)
         print(f"  Sub-diagram:   {sub_file}")
 
-    # Step 6: Generate viewer bundle for the website
-    print("Generating viewer bundle ...")
-    from noodles.viewer.data_loader import load_result
-    viewer_bundle = load_result(result_dir)
-    viewer_bundle_file = result_dir / "viewer_bundle.json"
-    viewer_bundle_file.write_text(json.dumps(viewer_bundle))
-    print(f"  Viewer bundle: {viewer_bundle_file}")
+    # Step 6: Generate viewer bundle and HTML
+    from noodles.viewer.data_loader import write_viewer_files
+    write_viewer_files(result_dir)
 
     return result_dir
 

--- a/src/noodles/viewer/data_loader.py
+++ b/src/noodles/viewer/data_loader.py
@@ -120,3 +120,63 @@ def load_result(result_dir: str | Path) -> dict:
         "edges": edges,
         "id_map": id_map,
     }
+
+
+def write_viewer_files(result_dir: str | Path) -> None:
+    """Generate and write viewer bundle and HTML files.
+
+    Args:
+        result_dir: Path to the result folder containing call_graph.json
+                    and diagram_*.mmd files.
+
+    Writes:
+        - viewer_bundle.json: JSON data bundle for the viewer
+        - viewer.html: Self-contained HTML viewer with embedded data
+    """
+    result_path = Path(result_dir)
+
+    print("Generating viewer bundle ...")
+    viewer_bundle = load_result(result_path)
+    viewer_bundle_file = result_path / "viewer_bundle.json"
+    viewer_bundle_file.write_text(json.dumps(viewer_bundle))
+    print(f"  Viewer bundle: {viewer_bundle_file}")
+
+    viewer_html = generate_viewer_html(result_path)
+    viewer_html_file = result_path / "viewer.html"
+    viewer_html_file.write_text(viewer_html)
+    print(f"  Viewer HTML:   {viewer_html_file}")
+
+
+def generate_viewer_html(result_dir: str | Path) -> str:
+    """Generate a self-contained HTML viewer with embedded data.
+
+    Args:
+        result_dir: Path to the result folder containing call_graph.json
+                    and diagram_*.mmd files.
+
+    Returns:
+        Complete HTML string that can be saved as viewer.html.
+    """
+    bundle = load_result(result_dir)
+    template_path = Path(__file__).parent / "static/index.html"
+    template = template_path.read_text(encoding="utf-8")
+
+    # Replace the fetch() block with inline data
+    # Original pattern fetches from /api/data, we replace with embedded JSON
+    fetch_block = """fetch('/api/data')
+    .then(r => r.json())
+    .then(data => {
+      DATA = data;
+      loading.style.display = 'none';
+      navigateTo('main', 'Main');
+    })
+    .catch(err => {
+      loading.textContent = 'Failed to load data: ' + err.message;
+    });"""
+
+    inline_code = f"""DATA = {json.dumps(bundle)};
+  loading.style.display = 'none';
+  navigateTo('main', 'Main');"""
+
+    html = template.replace(fetch_block, inline_code)
+    return html

--- a/src/noodles/viewer/data_loader.py
+++ b/src/noodles/viewer/data_loader.py
@@ -174,9 +174,13 @@ def generate_viewer_html(result_dir: str | Path) -> str:
       loading.textContent = 'Failed to load data: ' + err.message;
     });"""
 
+    # Use setTimeout to defer execution until after all variables are declared
+    # (the original fetch was async so this wasn't needed)
     inline_code = f"""DATA = {json.dumps(bundle)};
-  loading.style.display = 'none';
-  navigateTo('main', 'Main');"""
+  setTimeout(() => {{
+    loading.style.display = 'none';
+    navigateTo('main', 'Main');
+  }}, 0);"""
 
     html = template.replace(fetch_block, inline_code)
     return html

--- a/src/noodles/viewer/static/index.html
+++ b/src/noodles/viewer/static/index.html
@@ -237,6 +237,14 @@
 
 <script>
 (function() {
+  // ---- HTML escaping for XSS prevention ----
+  function escapeHtml(str) {
+    if (str == null) return '';
+    const div = document.createElement('div');
+    div.textContent = String(str);
+    return div.innerHTML;
+  }
+
   // ---- State ----
   let DATA = null;       // data bundle from /api/data
   let navStack = [];     // [{diagramName, title}]
@@ -269,7 +277,7 @@
     startOnLoad: false,
     theme: 'default',
     flowchart: { curve: 'basis', useMaxWidth: false },
-    securityLevel: 'loose',
+    securityLevel: 'strict',
   });
 
   fetch('/api/data')
@@ -396,17 +404,18 @@
   // ---- Tooltips ----
   function showNodeTooltip(e, meta, mermaidId) {
     if (!meta) {
-      tooltip.innerHTML = `<div class="tt-name">${mermaidId}</div>`;
+      tooltip.innerHTML = `<div class="tt-name">${escapeHtml(mermaidId)}</div>`;
     } else {
-      const badge = `<span class="tt-badge ${meta.type}">${meta.type.replace('_',' ')}</span>`;
-      const tagHtml = meta.tag ? `<span class="tt-badge ${meta.tag}">${meta.tag}</span>` : '';
+      const typeText = escapeHtml((meta.type || '').replace('_',' '));
+      const badge = `<span class="tt-badge ${escapeHtml(meta.type)}">${typeText}</span>`;
+      const tagHtml = meta.tag ? `<span class="tt-badge ${escapeHtml(meta.tag)}">${escapeHtml(meta.tag)}</span>` : '';
       const updateHtml = (meta.status === 'updated' && meta.update)
-        ? `<div class="tt-update">${meta.update}</div>`
+        ? `<div class="tt-update">${escapeHtml(meta.update)}</div>`
         : '';
       tooltip.innerHTML = `
-        <div class="tt-name">${meta.name}${badge}${tagHtml}</div>
-        ${meta.description ? `<div class="tt-desc">${meta.description}</div>` : ''}
-        ${meta.file_path ? `<div class="tt-file">${meta.file_path}::${meta.function}</div>` : ''}
+        <div class="tt-name">${escapeHtml(meta.name)}${badge}${tagHtml}</div>
+        ${meta.description ? `<div class="tt-desc">${escapeHtml(meta.description)}</div>` : ''}
+        ${meta.file_path ? `<div class="tt-file">${escapeHtml(meta.file_path)}::${escapeHtml(meta.function)}</div>` : ''}
         ${updateHtml}
       `;
     }
@@ -426,15 +435,15 @@
     }
 
     if (edgeMeta) {
-      let html = `<div class="tt-edge-label">${edgeMeta.label}</div>`;
-      if (edgeMeta.description) html += `<div class="tt-desc">${edgeMeta.description}</div>`;
-      const idx = edgeMeta.index != null ? edgeMeta.index : 'N/A';
+      let html = `<div class="tt-edge-label">${escapeHtml(edgeMeta.label)}</div>`;
+      if (edgeMeta.description) html += `<div class="tt-desc">${escapeHtml(edgeMeta.description)}</div>`;
+      const idx = edgeMeta.index != null ? escapeHtml(edgeMeta.index) : 'N/A';
       html += `<div class="tt-row">Index: <span>${idx}</span></div>`;
-      const cond = edgeMeta.condition || 'None';
+      const cond = escapeHtml(edgeMeta.condition) || 'None';
       html += `<div class="tt-row">Condition: <span>${cond}</span></div>`;
       tooltip.innerHTML = html;
     } else {
-      tooltip.innerHTML = `<div class="tt-edge-label">${labelText}</div>`;
+      tooltip.innerHTML = `<div class="tt-edge-label">${escapeHtml(labelText)}</div>`;
     }
     tooltip.style.display = 'block';
     positionTooltip(e);
@@ -486,7 +495,7 @@
     navStack.forEach((item, i) => {
       if (i > 0) html += '<span class="crumb-sep">›</span>';
       const isCurrent = i === navStack.length - 1;
-      html += `<span class="crumb ${isCurrent ? 'current' : ''}" data-index="${i}">${item.title}</span>`;
+      html += `<span class="crumb ${isCurrent ? 'current' : ''}" data-index="${i}">${escapeHtml(item.title)}</span>`;
     });
     breadcrumb.innerHTML = html;
 


### PR DESCRIPTION
## Summary

- Generate self-contained `viewer.html` with embedded data (no server required)
- Add XSS protection: `escapeHtml()` for all dynamic tooltip/breadcrumb content
- Tighten mermaid security level from `loose` to `strict`
- Fix git fetch auth for private repos
- Extract `write_viewer_files()` helper to consolidate viewer generation
- Fix TDZ error in generated viewer.html (defer `navigateTo` with setTimeout)

## Breaking Changes

None - this is additive. Existing `viewer_bundle.json` is still generated alongside `viewer.html`.

## Test plan

- [x] Run local analysis, verify `viewer.html` opens standalone in browser
- [x] Verify tooltips display correctly with escaped content
- [x] Verify node clicking/navigation still works with `securityLevel: 'strict'`
- [x] Deploy Lambda, trigger PR analysis, verify iframe loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)