### PR TITLE
Add local-path analysis functions for embedded use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "noodles"
-version = "0.2.0"
+version = "0.3.0"
 description = "AI-powered code visualization and call graph analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/noodles/__init__.py
+++ b/src/noodles/__init__.py
@@ -12,11 +12,28 @@ from noodles.llm import (
     get_pricing,
 )
 
+from noodles.agents.repo_analyzer.repo_analyzer import (
+    analyze_repo,
+    analyze_local_repo,
+)
+
+from noodles.agents.pr_analyzer.pr_analyzer import (
+    analyze_pr,
+    analyze_local_changes,
+)
+
 __all__ = [
     "__version__",
+    # LLM utilities
     "get_provider",
     "LLMProvider",
     "LLMResponse",
     "calculate_cost",
     "get_pricing",
+    # Repo analysis
+    "analyze_repo",
+    "analyze_local_repo",
+    # PR/change analysis
+    "analyze_pr",
+    "analyze_local_changes",
 ]

--- a/src/noodles/agents/pr_analyzer/pr_analyzer.py
+++ b/src/noodles/agents/pr_analyzer/pr_analyzer.py
@@ -52,7 +52,42 @@ async def analyze_pr(
         return None
     base_path, head_path = setup
 
-    # Step 2: Build PR call graph (tree-sitter compares base vs head)
+    # Use shared implementation
+    return await _analyze_changes_impl(base_path, head_path, result_dir)
+
+
+async def analyze_local_changes(
+    base_path: Path,
+    head_path: Path,
+    output_dir: Path,
+) -> Path:
+    """Analyze changes between two local paths (no cloning needed).
+
+    Args:
+        base_path: Path to the base version of the repository
+        head_path: Path to the head version of the repository
+        output_dir: Directory to write results to
+
+    Produces in output_dir:
+      call_graph.json     - pruned call graph with change status
+      classification.json - functions classified as new/updated/deleted
+      start_points.json   - functions with out-degree only
+      end_points.json     - functions with in-degree only
+      orphans.json        - functions with no connections
+
+    Returns the output directory path.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return await _analyze_changes_impl(base_path, head_path, output_dir)
+
+
+async def _analyze_changes_impl(
+    base_path: Path,
+    head_path: Path,
+    result_dir: Path,
+) -> Path:
+    """Shared implementation for change analysis."""
+    # Step 1: Build PR call graph (tree-sitter compares base vs head)
     print("Building PR call graph ...")
     (
         call_graph,
@@ -62,13 +97,13 @@ async def analyze_pr(
         classification,
     ) = build_pr_call_graph(base_path, head_path)
 
-    # Step 3: Enrich call graph with full tree builder
+    # Step 2: Enrich call graph with full tree builder
     print("Enriching call graph with full tree builder ...")
     call_graph = await build_full_graph(
         call_graph, str(head_path), output_dir=result_dir
     )
 
-    # Step 4: Save results (strip source code from nodes to keep output clean)
+    # Step 3: Save results (strip source code from nodes to keep output clean)
     for node in call_graph["nodes"]:
         node.pop("source", None)
         node.pop("base_source", None)
@@ -101,7 +136,7 @@ async def analyze_pr(
     )
     print(f"  Classification: {classification_file}")
 
-    # Step 5: Generate mermaid diagrams
+    # Step 4: Generate mermaid diagrams
     print("Generating mermaid diagrams ...")
     diagrams = build_diagrams(call_graph, start_points)
 
@@ -114,7 +149,7 @@ async def analyze_pr(
         sub_file.write_text(sub_content)
         print(f"  Sub-diagram:   {sub_file}")
 
-    # Step 6: Generate viewer bundle and HTML
+    # Step 5: Generate viewer bundle and HTML
     from noodles.viewer.data_loader import write_viewer_files
     write_viewer_files(result_dir)
 

--- a/src/noodles/agents/repo_analyzer/repo_analyzer.py
+++ b/src/noodles/agents/repo_analyzer/repo_analyzer.py
@@ -46,17 +46,53 @@ async def analyze_repo(
     if not _clone_repo(repo_url, repo_dir):
         return None
 
-    # Step 2: Build the AST call graph
+    # Use shared implementation
+    return await _analyze_repo_impl(repo_dir, result_dir, enrich=True)
+
+
+async def analyze_local_repo(
+    repo_path: Path,
+    output_dir: Path,
+    enrich: bool = True,
+) -> Path:
+    """Analyze a local repository (no cloning needed).
+
+    Args:
+        repo_path: Path to the local repository
+        output_dir: Directory to write results to
+        enrich: If True, run LLM enrichment (slower, costs API calls).
+                If False, only build the AST-based call graph (fast).
+
+    Produces in output_dir:
+      call_graph.json    - all functions with type and connections
+      start_points.json  - functions with out-degree only (not called by anyone)
+      end_points.json    - functions with in-degree only (call nobody)
+      orphans.json       - functions with no connections at all
+
+    Returns the output directory path.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return await _analyze_repo_impl(repo_path, output_dir, enrich=enrich)
+
+
+async def _analyze_repo_impl(
+    repo_path: Path,
+    result_dir: Path,
+    enrich: bool = True,
+) -> Path:
+    """Shared implementation for repo analysis."""
+    # Step 1: Build the AST call graph
     print("Building call graph ...")
-    call_graph, start_points, end_points, orphans = build_call_graph(repo_dir)
+    call_graph, start_points, end_points, orphans = build_call_graph(repo_path)
 
-    # Step 3: Enrich call graph with full tree builder
-    print("Enriching call graph with full tree builder ...")
-    call_graph = await build_full_graph(
-        call_graph, str(repo_dir), output_dir=result_dir
-    )
+    # Step 2: Optionally enrich call graph with full tree builder
+    if enrich:
+        print("Enriching call graph with full tree builder ...")
+        call_graph = await build_full_graph(
+            call_graph, str(repo_path), output_dir=result_dir
+        )
 
-    # Step 4: Save results (strip source code from nodes to keep output clean)
+    # Step 3: Save results (strip source code from nodes to keep output clean)
     for node in call_graph["nodes"]:
         node.pop("source", None)
     call_graph_file = result_dir / "call_graph.json"
@@ -75,7 +111,7 @@ async def analyze_repo(
     orphans_file.write_text(json.dumps(orphans, indent=2))
     print(f"  Orphans:       {orphans_file} ({len(orphans)} functions)")
 
-    # Step 5: Generate mermaid diagrams
+    # Step 4: Generate mermaid diagrams
     print("Generating mermaid diagrams ...")
     diagrams = build_diagrams(call_graph, start_points)
 
@@ -88,7 +124,7 @@ async def analyze_repo(
         sub_file.write_text(sub_content)
         print(f"  Sub-diagram:   {sub_file}")
 
-    # Step 6: Generate viewer bundle and HTML
+    # Step 5: Generate viewer bundle and HTML
     from noodles.viewer.data_loader import write_viewer_files
     write_viewer_files(result_dir)
 


### PR DESCRIPTION
## Summary
- Add `analyze_local_repo()` for analyzing repos without cloning
- Add `analyze_local_changes()` for analyzing changes between local paths
- Export both functions from package `__init__.py`
- Bump version to 0.3.0

## Motivation
These functions allow noodles to be used as a library by applications that already have repos checked out locally (e.g., dave).

## Test plan
- [x] Verify imports work: `from noodles import analyze_local_repo, analyze_local_changes`
- [x] Test `analyze_local_repo()` with structure mode on dave's src/agents
- [x] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)