### PR TITLE
Fix: Clone repos to temp directory instead of package directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-03-03
+
+### Fixed
+- Clone repos to temp directory instead of package directory to avoid empty call graphs when installed via `uv tool` on Windows (fixes #20)
+
 ## [0.4.1] - 2026-03-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "noodles"
-version = "0.4.1"
+version = "0.4.2"
 description = "AI-powered code visualization and call graph analysis"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/noodles/agents/pr_analyzer/pr_analyzer.py
+++ b/src/noodles/agents/pr_analyzer/pr_analyzer.py
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import uuid
 from pathlib import Path
 
@@ -42,9 +43,17 @@ async def analyze_pr(
     Returns the result directory path, or None on failure.
     """
     result_id = analysis_id or uuid.uuid4().hex[:12]
-    base_dir = output_dir or AGENT_DIR
-    result_dir = base_dir / f"result_{result_id}"
-    result_dir.mkdir(parents=True, exist_ok=True)
+
+    # Use temp directory to avoid path issues (e.g., site-packages on Windows)
+    temp_base = Path(tempfile.gettempdir()) / "noodles_pr"
+    temp_base.mkdir(parents=True, exist_ok=True)
+    temp_dir = temp_base / f"result_{result_id}"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+
+    # Results go to output_dir if specified, otherwise temp
+    result_dir = output_dir or temp_dir
+    if output_dir:
+        result_dir.mkdir(parents=True, exist_ok=True)
 
     # Step 1: Parse PR URL and clone repo
     print(f"Analyzing PR: {pr_url}")
@@ -55,7 +64,7 @@ async def analyze_pr(
         return None
 
     print("Cloning repository and setting up branches ...")
-    setup = _clone_and_setup(owner, repo, pr_number, result_dir)
+    setup = _clone_and_setup(owner, repo, pr_number, temp_dir)
     if setup is None:
         return None
     base_path, head_path = setup
@@ -225,7 +234,7 @@ def _clone_and_setup(
     owner: str,
     repo: str,
     pr_number: int,
-    result_dir: Path,
+    clone_dir: Path,
 ) -> tuple[Path, Path] | None:
     """Clone repo and set up base/head branches using pure git.
 
@@ -238,8 +247,8 @@ def _clone_and_setup(
 
     Returns (base_path, head_path) or None on failure.
     """
-    repo_dir = result_dir / "repo"
-    base_dir = result_dir / "base"
+    repo_dir = clone_dir / "repo"
+    base_dir = clone_dir / "base"
 
     # Clone the repository (using gh for private repo support)
     print(f"  Cloning {owner}/{repo} ...")

--- a/src/noodles/agents/repo_analyzer/repo_analyzer.py
+++ b/src/noodles/agents/repo_analyzer/repo_analyzer.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import subprocess
 import sys
+import tempfile
 import uuid
 import webbrowser
 from pathlib import Path
@@ -44,12 +45,20 @@ async def analyze_repo(
     Returns the result directory path, or None on failure.
     """
     result_id = analysis_id or uuid.uuid4().hex[:12]
-    base_dir = output_dir or AGENT_DIR
-    result_dir = base_dir / f"result_{result_id}"
-    result_dir.mkdir(parents=True, exist_ok=True)
 
-    # Step 1: Clone the repo
-    repo_dir = result_dir / "repo"
+    # Use temp directory to avoid path issues (e.g., site-packages on Windows)
+    temp_base = Path(tempfile.gettempdir()) / "noodles_repo"
+    temp_base.mkdir(parents=True, exist_ok=True)
+    temp_dir = temp_base / f"result_{result_id}"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+
+    # Results go to output_dir if specified, otherwise temp
+    result_dir = output_dir or temp_dir
+    if output_dir:
+        result_dir.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: Clone the repo (always to temp)
+    repo_dir = temp_dir / "repo"
     print(f"Cloning {repo_url} ...")
     if not _clone_repo(repo_url, repo_dir):
         return None

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "noodles"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- Clone repos to `/tmp/noodles_{repo|pr}/` instead of the package directory
- Fixes empty call graphs when installed via `uv tool` on Windows (site-packages path filtering)
- Results still go to `--output-dir` if specified, otherwise to temp directory

## Test plan
- [x] All existing tests pass (60/60)
- [x] Manual test: `noodles repo --no-view https://github.com/unslop-xyz/noodles` produces non-empty call graph
- [x] Manual test: `noodles repo --output-dir ./test_output --no-view https://github.com/unslop-xyz/noodles` saves results to specified directory

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)